### PR TITLE
Add free program screens and gating

### DIFF
--- a/App.js
+++ b/App.js
@@ -4,9 +4,11 @@ import { NavigationContainer } from '@react-navigation/native';
 import { createNativeStackNavigator } from '@react-navigation/native-stack';
 
 
-import HomeScreen    from './screens/HomeScreen';
-import ChatScreen    from './screens/ChatScreen';
-import PlannerScreen from './screens/PlannerScreen';
+import HomeScreen            from './screens/HomeScreen';
+import ProgramSelectScreen   from './screens/ProgramSelectScreen';
+import ProgramDetailScreen   from './screens/ProgramDetailScreen';
+import ChatScreen            from './screens/ChatScreen';
+import PlannerScreen         from './screens/PlannerScreen';
 import MacroCalculatorScreen from './screens/MacroCalculatorScreen';
 
 const Stack = createNativeStackNavigator();
@@ -15,14 +17,24 @@ export default function App() {
   return (
     <NavigationContainer>
       <Stack.Navigator initialRouteName="Home">
-        <Stack.Screen 
-          name="Home" 
-          component={HomeScreen} 
+        <Stack.Screen
+          name="Home"
+          component={HomeScreen}
           options={{ title: 'Coach App' }}
         />
-        <Stack.Screen 
-          name="Chat" 
-          component={ChatScreen} 
+        <Stack.Screen
+          name="Programs"
+          component={ProgramSelectScreen}
+          options={{ title: 'Programs' }}
+        />
+        <Stack.Screen
+          name="ProgramDetail"
+          component={ProgramDetailScreen}
+          options={({ route }) => ({ title: route.params?.program?.title || 'Program' })}
+        />
+        <Stack.Screen
+          name="Chat"
+          component={ChatScreen}
           options={{ title: 'Chat with Coach' }}
         />
         <Stack.Screen 

--- a/README.md
+++ b/README.md
@@ -1,0 +1,29 @@
+# Coach Angel App
+
+This Expo/React Native project is a lightweight prototype of the **Coach Angel** concept.
+It showcases the free training programs and gates premium features behind a simple
+boolean flag.
+
+## Free Features
+- Browse three core programs: Hypertrophy, Powerlifting and Cardio.
+- View basic details for each program.
+
+## Premium Features (stubbed)
+When `IS_PREMIUM` in `lib/constants.js` is set to `true` the following screens
+become accessible from the home screen:
+- AI Chat Coach
+- Custom Workout Planner
+- Macro Calculator
+
+These screens are placeholders and can be extended with real functionality.
+
+## Disclaimers
+All content is for educational purposes only and does **not** constitute medical
+or professional advice.
+
+## Running
+Install dependencies with `yarn` or `npm install` and start Expo:
+
+```bash
+npm start
+```

--- a/lib/constants.js
+++ b/lib/constants.js
@@ -1,0 +1,22 @@
+export const IS_PREMIUM = false; // Toggle to true for premium features
+
+export const PROGRAMS = [
+  {
+    id: 'hypertrophy',
+    title: 'Hypertrophy Program',
+    description:
+      '12–16-week strength-building split with weekly progression templates.',
+  },
+  {
+    id: 'powerlifting',
+    title: 'Powerlifting Program',
+    description:
+      'Structured periodization for squat, bench, and deadlift with percentage-based loading.',
+  },
+  {
+    id: 'cardio',
+    title: 'Cardio Program',
+    description:
+      'Phased running or cycling plan with preset intervals and weekly volume targets.',
+  },
+];

--- a/screens/HomeScreen.js
+++ b/screens/HomeScreen.js
@@ -12,6 +12,7 @@ import {
 import { LinearGradient } from 'expo-linear-gradient';
 import { Ionicons } from '@expo/vector-icons';
 import colors from '../theme/colors';
+import { IS_PREMIUM } from '../lib/constants';
 
 const { width } = Dimensions.get('window');
 
@@ -26,47 +27,68 @@ export default function HomeScreen({ navigation }) {
         </View>
 
         <View style={styles.buttonContainer}>
-          {/* Chat with Coach */}
+          {/* Free Programs */}
           <TouchableOpacity
             style={styles.card}
-            onPress={() => navigation.navigate('Chat')}
+            onPress={() => navigation.navigate('Programs')}
             activeOpacity={0.8}
           >
-            <LinearGradient colors={[colors.blue, colors.cyan]} style={styles.iconCircle}>
-              <Ionicons name="chatbubbles-outline" size={28} color={colors.white} />
+            <LinearGradient colors={[colors.cyan, colors.blue]} style={styles.iconCircle}>
+              <Ionicons name="list" size={28} color={colors.white} />
             </LinearGradient>
-            <Text style={styles.cardTitle}>Chat with Coach</Text>
-            <Text style={styles.cardSubtitle}>Instant AI Q&A</Text>
+            <Text style={styles.cardTitle}>Free Programs</Text>
+            <Text style={styles.cardSubtitle}>Hypertrophy, Powerlifting, Cardio</Text>
           </TouchableOpacity>
 
-          {/* Workout Planner */}
-          <TouchableOpacity
-            style={styles.card}
-            onPress={() => navigation.navigate('Planner')}
-            activeOpacity={0.8}
-          >
-            <LinearGradient colors={[colors.blue, colors.purple]} style={styles.iconCircle}>
-              <Ionicons name="barbell-outline" size={28} color={colors.white} />
-            </LinearGradient>
-            <Text style={styles.cardTitle}>Workout Planner</Text>
-            <Text style={styles.cardSubtitle}>Generate custom plans</Text>
-          </TouchableOpacity>
+          {IS_PREMIUM && (
+            <>
+              {/* Chat with Coach */}
+              <TouchableOpacity
+                style={styles.card}
+                onPress={() => navigation.navigate('Chat')}
+                activeOpacity={0.8}
+              >
+                <LinearGradient colors={[colors.blue, colors.cyan]} style={styles.iconCircle}>
+                  <Ionicons name="chatbubbles-outline" size={28} color={colors.white} />
+                </LinearGradient>
+                <Text style={styles.cardTitle}>Chat with Coach</Text>
+                <Text style={styles.cardSubtitle}>Instant AI Q&A</Text>
+              </TouchableOpacity>
 
-          {/* Macros & Calories */}
-          <TouchableOpacity
-            style={styles.card}
-            onPress={() => navigation.navigate('Macros')}
-            activeOpacity={0.8}
-          >
-            <LinearGradient colors={[colors.cyan, colors.purple]} style={styles.iconCircle}>
-              <Ionicons name="calculator-outline" size={28} color={colors.white} />
-            </LinearGradient>
-            <Text style={styles.cardTitle}>Macros & Calories</Text>
-            <Text style={styles.cardSubtitle}>Calculate your intake</Text>
-          </TouchableOpacity>
+              {/* Workout Planner */}
+              <TouchableOpacity
+                style={styles.card}
+                onPress={() => navigation.navigate('Planner')}
+                activeOpacity={0.8}
+              >
+                <LinearGradient colors={[colors.blue, colors.purple]} style={styles.iconCircle}>
+                  <Ionicons name="barbell-outline" size={28} color={colors.white} />
+                </LinearGradient>
+                <Text style={styles.cardTitle}>Workout Planner</Text>
+                <Text style={styles.cardSubtitle}>Generate custom plans</Text>
+              </TouchableOpacity>
+
+              {/* Macros & Calories */}
+              <TouchableOpacity
+                style={styles.card}
+                onPress={() => navigation.navigate('Macros')}
+                activeOpacity={0.8}
+              >
+                <LinearGradient colors={[colors.cyan, colors.purple]} style={styles.iconCircle}>
+                  <Ionicons name="calculator-outline" size={28} color={colors.white} />
+                </LinearGradient>
+                <Text style={styles.cardTitle}>Macros & Calories</Text>
+                <Text style={styles.cardSubtitle}>Calculate your intake</Text>
+              </TouchableOpacity>
+            </>
+          )}
         </View>
 
+        {!IS_PREMIUM && (
+          <Text style={styles.disclaimer}>Upgrade to Premium to unlock AI chat and more.</Text>
+        )}
         <Text style={styles.footer}>Start your transformation</Text>
+        <Text style={styles.disclaimer}>Not medical advice. For education only.</Text>
       </LinearGradient>
     </SafeAreaView>
   );
@@ -101,5 +123,6 @@ const styles = StyleSheet.create({
   },
   cardTitle:     { color: colors.white, fontSize: 18, fontWeight: '600' },
   cardSubtitle:  { color: colors.cyan, fontSize: 14, marginTop: 4 },
-  footer:        { color: colors.white, fontSize: 14, marginBottom: 24 },
+  footer:        { color: colors.white, fontSize: 14, marginBottom: 12 },
+  disclaimer:    { color: colors.lightGrey, fontSize: 12, marginBottom: 24 },
 });

--- a/screens/ProgramDetailScreen.js
+++ b/screens/ProgramDetailScreen.js
@@ -1,0 +1,29 @@
+// screens/ProgramDetailScreen.js
+import React from 'react';
+import { View, Text, StyleSheet, ScrollView } from 'react-native';
+import { LinearGradient } from 'expo-linear-gradient';
+import colors from '../theme/colors';
+
+export default function ProgramDetailScreen({ route }) {
+  const { program } = route.params;
+  return (
+    <ScrollView contentContainerStyle={styles.container}>
+      <LinearGradient colors={[colors.blue, colors.cyan]} style={styles.header}>
+        <Text style={styles.title}>{program.title}</Text>
+      </LinearGradient>
+      <Text style={styles.text}>{program.description}</Text>
+      <Text style={styles.text}>Week-by-week plan coming soon.</Text>
+      <Text style={styles.disclaimer}>
+        Educational purposes only. Not medical advice.
+      </Text>
+    </ScrollView>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: { padding: 20, backgroundColor: colors.black },
+  header: { padding: 20, borderRadius: 12, alignItems: 'center', marginBottom: 20 },
+  title: { color: colors.white, fontSize: 22, fontWeight: 'bold' },
+  text: { color: colors.lightGrey, fontSize: 16, marginBottom: 10 },
+  disclaimer: { marginTop: 20, color: colors.lightGrey, fontSize: 12, textAlign: 'center' },
+});

--- a/screens/ProgramSelectScreen.js
+++ b/screens/ProgramSelectScreen.js
@@ -1,0 +1,45 @@
+// screens/ProgramSelectScreen.js
+import React from 'react';
+import {
+  View,
+  Text,
+  TouchableOpacity,
+  StyleSheet,
+  ScrollView,
+} from 'react-native';
+import { LinearGradient } from 'expo-linear-gradient';
+import { PROGRAMS } from '../lib/constants';
+import colors from '../theme/colors';
+
+export default function ProgramSelectScreen({ navigation }) {
+  return (
+    <ScrollView contentContainerStyle={styles.container}>
+      <Text style={styles.header}>Choose a Free Program</Text>
+      {PROGRAMS.map(p => (
+        <TouchableOpacity
+          key={p.id}
+          style={styles.card}
+          onPress={() => navigation.navigate('ProgramDetail', { program: p })}
+        >
+          <LinearGradient colors={[colors.blue, colors.cyan]} style={styles.cardInner}>
+            <Text style={styles.cardTitle}>{p.title}</Text>
+            <Text style={styles.cardDesc}>{p.description}</Text>
+          </LinearGradient>
+        </TouchableOpacity>
+      ))}
+      <Text style={styles.disclaimer}>
+        Educational purposes only. Not medical advice.
+      </Text>
+    </ScrollView>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: { padding: 20, backgroundColor: colors.black },
+  header: { color: colors.white, fontSize: 22, fontWeight: 'bold', marginBottom: 20 },
+  card: { marginBottom: 16, borderRadius: 12, overflow: 'hidden' },
+  cardInner: { padding: 16 },
+  cardTitle: { color: colors.white, fontSize: 18, fontWeight: '600', marginBottom: 6 },
+  cardDesc: { color: colors.lightGrey, fontSize: 14 },
+  disclaimer: { marginTop: 30, color: colors.lightGrey, fontSize: 12, textAlign: 'center' },
+});


### PR DESCRIPTION
## Summary
- create constants with premium flag and program list
- add program selection and detail screens with disclaimers
- update Home screen to show free programs and gate premium features
- integrate new screens in navigation
- add README with overview

## Testing
- `npm start` *(fails: command not found or not run - we didn't run)*

------
https://chatgpt.com/codex/tasks/task_b_6843be9df0f08323920e75b4611e8d6d